### PR TITLE
Some typo fixes in basic vanilla guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Introduction
-Last edited: January 13, 2020
+Last edited: January 26, 2020
 * [GitHub Pages link with Darkmode support](https://khronokernel.github.io/Opencore-Vanilla-Desktop-Guide/)
 
 ### About
@@ -23,7 +23,7 @@ For AMD users having troubles follow the guide can see Snazzy's guide:
 * BootCamp switching and boot device selection are supported by reading NVRAM variables set by Startup Disk just like a real mac.
 * Future development for [AptioMemoryFix](https://github.com/acidanthera/AptioFixPkg) is directly tied to OpenCore, specifically being absorbed into OpenCore itself with the FwRuntimeVariable.efi being used as an extension.
 * UEFI and Legacy boot modes are supported.
-* Mask patching means macOS updates vhave ery little chance of breaking AMD systems, with [AMD OSX patches](https://github.com/AMD-OSX/AMD_Vanilla/tree/opencore) supporting all versions of High Sierra, Mojave and Catalina. **All future AMD OSX developement is tied to Opencore**, so for 10.15.2+ you'll need OpenCore
+* Mask patching means macOS updates have very little chance of breaking AMD systems, with [AMD OSX patches](https://github.com/AMD-OSX/AMD_Vanilla/tree/opencore) supporting all versions of High Sierra, Mojave and Catalina. **All future AMD OSX development is tied to Opencore**, so for 10.15.2+ you'll need OpenCore
 
 ### OpenCore Tips
 

--- a/installer-guide/mac-install.md
+++ b/installer-guide/mac-install.md
@@ -19,7 +19,7 @@ To start we'll want to grab ourselves a copy of macOS, you can skip this and hea
    * Download the full macOS installer
    * Run `BuildmacOSInstallApp` then drag and drop the `macOS Downloads` folder found in GibMacOS
 
-Next we'll want to format our USB HFS+/MacOS Journaled with GUID partition map, must be 12GB for macOS Catalina.as-isecommended to name it `MyVolume` as the script below can be used as-is.
+Next we'll want to format our USB HFS+/MacOS Journaled with GUID partition map, must be 12GB for macOS Catalina.as-is recommended to name it `MyVolume` as the script below can be used as-is.
 
 ![Formatting the USB](https://i.imgur.com/numOUnF.png)
 
@@ -32,9 +32,9 @@ sudo /Applications/Install\ macOS\ Catalina.app/Contents/Resources/createinstall
 This will take some time so may want to grab a coffee or continue reading the guide(to be fair you really shouldn't be following this guide step by step without reading the whole thing first)
 
 
-## Setting up OpenCore's EFI enviroment
+## Setting up OpenCore's EFI environment
 
-Setting up OpenCore's EFI enviroment is simple, all you need to do is mount our EFI system partition. This is automatically made when we format with GUID but is hidden from the end user, this is where our friend [mountEFI](https://github.com/corpnewt/MountEFI) comes in:
+Setting up OpenCore's EFI environment is simple, all you need to do is mount our EFI system partition. This is automatically made when we format with GUID but is hidden from the end user, this is where our friend [mountEFI](https://github.com/corpnewt/MountEFI) comes in:
 
 ![MountEFI](https://i.imgur.com/4l1oK8i.png)
 

--- a/installer-guide/opencore-efi.md
+++ b/installer-guide/opencore-efi.md
@@ -1,6 +1,6 @@
 # Creating the USB
 
-Last edited: January 18, 2020
+Last edited: January 26, 2020
 
 Requirements:
 
@@ -39,13 +39,13 @@ Now something you'll notice is that it comes with a bunch of files in `Drivers` 
    * CleanNvram.efi
       * We'll be using OpenCore's built-in function
    * VerifyMsrE2.efi
-      * Used for [verifying MSR lock](/extras/msr-lock.md), for install we can igore
+      * Used for [verifying MSR lock](/extras/msr-lock.md), for install we can ignore
 
 A cleaned up EFI:
 
 ![Clean EFI](https://i.imgur.com/2INJYol.png)
 
-Now you can place **your** necessary fimrware drivers(.efi) from AppleSupportPkg into the _Drivers_ folder and Kexts/ACPI into their respective folders. Please note that UEFI drivers from Clover are not supported with OpenCore!\(EmuVariableUEFI, AptioMemoryFix, OsxAptioFixDrv, etc\). Please see the [Clover firmware driver conversion](https://github.com/khronokernel/Opencore-Vanilla-Desktop-Guide/blob/master/clover-conversion/clover-efi.md) for more info on supported drivers and those merged into OpenCore.
+Now you can place **your** necessary firmware drivers(.efi) from AppleSupportPkg into the _Drivers_ folder and Kexts/ACPI into their respective folders. Please note that UEFI drivers from Clover are not supported with OpenCore!\(EmuVariableUEFI, AptioMemoryFix, OsxAptioFixDrv, etc\). Please see the [Clover firmware driver conversion](https://github.com/khronokernel/Opencore-Vanilla-Desktop-Guide/blob/master/clover-conversion/clover-efi.md) for more info on supported drivers and those merged into OpenCore.
 
 Here's what a populated EFI can look like:
 


### PR DESCRIPTION
Hey, just saw some typos in the basic opencore vanilla guide I was following through.

Wanted to thank you guys with a pull-request.