### PR TITLE
Fix typo.

### DIFF
--- a/AMD/AMD-config.md
+++ b/AMD/AMD-config.md
@@ -233,7 +233,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
    * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-   * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+   * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
    * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -293,7 +293,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt; 
    * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://khronokernel-3.gitbook.io/catalina-gpu-buyers-guide/). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel GPU users should leave this area blank.**

--- a/config-HEDT/broadwell-e.md
+++ b/config-HEDT/broadwell-e.md
@@ -214,7 +214,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
    * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-   * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+   * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
    * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -271,7 +271,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt; 
    * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://github.com/khronokernel/Catalina-GPU-Buyers-Guide/blob/master/README.md#Unsupported-nVidia-GPUs). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel GPU users should leave this area blank.**

--- a/config-HEDT/haswell-e.md
+++ b/config-HEDT/haswell-e.md
@@ -216,7 +216,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
    * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-   * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+   * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
    * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -273,7 +273,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt; 
    * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://github.com/khronokernel/Catalina-GPU-Buyers-Guide/blob/master/README.md#Unsupported-nVidia-GPUs). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel users should leave this area blank.**

--- a/config-HEDT/skylake-x.md
+++ b/config-HEDT/skylake-x.md
@@ -212,7 +212,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
    * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-   * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+   * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
    * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -267,7 +267,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt; 
    * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://github.com/khronokernel/Catalina-GPU-Buyers-Guide/blob/master/README.md#Unsupported-nVidia-GPUs). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel users should leave this area blank.**

--- a/config.plist/coffee-lake.md
+++ b/config.plist/coffee-lake.md
@@ -257,7 +257,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
   * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
   * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -318,7 +318,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt;
   * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://github.com/khronokernel/Catalina-GPU-Buyers-Guide/blob/master/README.md#Unsupported-nVidia-GPUs). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel GPU users should leave this area blank.**

--- a/config.plist/haswell.md
+++ b/config.plist/haswell.md
@@ -244,7 +244,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
   * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
   * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -301,7 +301,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt; 
   * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://github.com/khronokernel/Catalina-GPU-Buyers-Guide/blob/master/README.md#Unsupported-nVidia-GPUs). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel GPU users should leave this area blank.**

--- a/config.plist/ivy-bridge.md
+++ b/config.plist/ivy-bridge.md
@@ -247,7 +247,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
   * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
   * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -305,7 +305,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt; 
   * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://github.com/khronokernel/Catalina-GPU-Buyers-Guide/blob/master/README.md#Unsupported-nVidia-GPUs). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel GPU users should leave this area blank.**

--- a/config.plist/kaby-lake.md
+++ b/config.plist/kaby-lake.md
@@ -236,7 +236,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
   * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
   * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -293,7 +293,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt; 
   * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://github.com/khronokernel/Catalina-GPU-Buyers-Guide/blob/master/README.md#Unsupported-nVidia-GPUs). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel GPU users should leave this area blank.**

--- a/config.plist/skylake.md
+++ b/config.plist/skylake.md
@@ -236,7 +236,7 @@ These values are based of those calculated in [OpenCore debugging](/troubleshoot
 * **AllowSetDefault**: YES
   * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **AuthRestart**: NO:
-  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional
+  * Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional
 * **ExposeSensitiveData**: `6`
   * Shows more debug information, requires debug version of OpenCore
 * **RequireSignature**: NO
@@ -291,7 +291,7 @@ csr-active-config is set to `00000000` which enables System Integrity Protection
 * `30000000` - Allow unsigned kexts and writing to protected fs locations
 * `E7030000` - SIP completely disabled
 
-Recommended to leave enabled for best secuirty practices
+Recommended to leave enabled for best security practices
 
 * **nvda\_drv**: &lt;&gt;
 * For enabling Nvidia WebDrivers, set to 31 if running a [Maxwell or Pascal GPU](https://github.com/khronokernel/Catalina-GPU-Buyers-Guide/blob/master/README.md#Unsupported-nVidia-GPUs). This is the same as setting nvda\_drv=1 but instead we translate it from [text to hex](https://www.browserling.com/tools/hex-to-text), Clover equivalent is `NvidiaWeb`. **AMD and Intel GPU users should leave this area blank.**

--- a/post-install/security.md
+++ b/post-install/security.md
@@ -21,7 +21,7 @@ Setting in your config.plist:
 * Misc -&gt; Boot 
   * `PollAppleHotKeys` set to YES(While not needed can be helpfu\)
 * Misc -&gt; Security
-  * `AuthRestart` set to YES(Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional)
+  * `AuthRestart` set to YES(Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional)
 * NVRAM -&gt; Add -&gt; 4D1EDE05-38C7-4A6A-9CC6-4BCCA8B38C14
   * `UIScale` set to `02` for high resolution small displays
 * UEFI -&gt; Input
@@ -128,8 +128,8 @@ Do note that nvram.plist won't be vaulted so users with emulated NVRAM still hav
 
 **Settings in your config.plist**:
 
-* `Misc -> Secuirty -> RequireSignature` set to True
-* `Misc -> Secuirty -> RequireVault` set to True
+* `Misc -> Security -> RequireSignature` set to True
+* `Misc -> Security -> RequireVault` set to True
 
 **Setting up vault**:
 
@@ -155,5 +155,5 @@ Now we're ready to run `sign.command`:
 If you're doing heavy troublehooting or have the need to disable Vault, the main things to change:
 
 * Grab a new copy of OpenCore.efi
-* `Misc -> Secuirty -> RequireSignature` set to False
-* `Misc -> Secuirty -> RequireVault` set to False
+* `Misc -> Security -> RequireSignature` set to False
+* `Misc -> Security -> RequireVault` set to False

--- a/troubleshooting/troubleshooting.md
+++ b/troubleshooting/troubleshooting.md
@@ -174,7 +174,7 @@ See [Fixing KALSR slide values](https://khronokernel-2.gitbook.io/opencore-vanil
 
 ## SSDTs not being added
 
-So with Opencore, there's some extra secuirty checks added around ACPI files, specifically that table length header must equal to the file size. This is actually the fault of iASL when you compiled the file. Example of how to find it:
+So with Opencore, there's some extra security checks added around ACPI files, specifically that table length header must equal to the file size. This is actually the fault of iASL when you compiled the file. Example of how to find it:
 
 ```
 * Original Table Header:

--- a/update.md
+++ b/update.md
@@ -14,7 +14,7 @@
 * ~~Add info for FileVault, AppleSmcIo~~
    * ~~Reinstalls Apple SMC I/O, this is the equivlant of VirtualSMC.efi~~
 * ~~Add AuthRestart info~~
-   * ~~Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a secuirty risk so optional~~
+   * ~~Enables Authenticated restart for FileVault2 so password is not required on reboot. Can be concidered a security risk so optional~~
 * ~~AllowSetDefault~~
    * Allow CTRL+Enter and CTRL+Index to set default boot device in the picker
 * ~~Add SupportsCsm info for Windows~~


### PR DESCRIPTION
Fixes `Secuirty`->`Security` across the guide.