### PR TITLE
Update verbose.md

### DIFF
--- a/troubleshooting/verbose.md
+++ b/troubleshooting/verbose.md
@@ -22,11 +22,10 @@ Wanting a more clean booting experience with macOS without all that verbose text
 
 **`Misc -> Boot`**:
 
-* `Resolution`: set to your monitor's resolution
+* `Resolution`: set to your monitor's resolution WxH@Bpp (e.g. 1920x1080@32) or WxH (e.g. 1920x1080)
 * `ConsoleBehaviourOs`: set to Graphics
 * `ConsoleBehaviourUi`: set to Text
-* `ConsoleMode` set to Max
-  * Setting to Max can infact break the resolution, if having issues set this to blank
+* `ConsoleMode`: set to blank string
 
 Please refer below for other settings if these Misc/Boot values do not work for your firmware.
 


### PR DESCRIPTION
OC Configuration.pdf: 
1) Note: This field is best to be left empty on most firmwares 
2) On all known affected systems ConsoleMode had to be set to empty string for this to work.